### PR TITLE
Fix Discord links in ReleaseNotes.md

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -10,9 +10,9 @@
 
 ### Independent Unreal Tournament Web Sites and Discord servers
 
-* [OldUnreal site](https://www.oldunreal.com) / [OldUnreal Discord](https://discord.com/channels/143986633992175616/1053202987545264128)
+* [OldUnreal site](https://www.oldunreal.com) / [OldUnreal Discord](https://discord.gg/thURucxzs6)
 * [MiA Forums](https://www.miasma.rocks)  / [MiA Discord](https://discord.gg/CxdXaEauya)
-* [CEONS Forums](https://ceonss.net/) / [CEONS Discord](https://discord.com/channels/310878149158240257/310878149158240257)
+* [CEONS Forums](https://ceonss.net/) / [CEONS Discord](https://discord.gg/X4V8THM)
 
 ## Unreal Tournament 2004 Version 3374 Release Notes
 


### PR DESCRIPTION
Previously they were Discord channel URLs which assume you are already logged in to Discord and are in these servers, this PR fixes that with invite links pulled directly from the sites themselves 